### PR TITLE
Fix minor typo in svg-framework/index.md

### DIFF
--- a/documents/pages/icon-components/svg-framework/index.md
+++ b/documents/pages/icon-components/svg-framework/index.md
@@ -41,7 +41,7 @@ src: icon-components/iconify/index-sample0.html
 demo: true
 ```
 
-To change an icon, write a different icon name in the `[attr]data-icon` attribute instead of `[str]"fa-regular:home"`.
+To change an icon, write a different icon name in the `[attr]data-icon` attribute instead of `[str]"fa-solid:home"`.
 
 Look in [icon collections](https://icon-sets.iconify.design/) to find icons. Click an icon to see HTML code for that icon.
 


### PR DESCRIPTION
There is a minor typo where the text after the code block says `fa-regular:home` while the code example itself uses `fa-solid:home`